### PR TITLE
Add domain-schema id validation

### DIFF
--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -46,8 +46,18 @@ export default class DomainValidator {
                 collector[fieldName] = result;
               }
             });
-          } else if (!schemaField.blackbox) {
+          } else if (!schemaField.blackbox && !schemaField.optional) {
             validateSchema(values[fieldName], schema[fieldName].type.values, collector);
+          } else if (!schemaField.blackbox && schemaField.optional) {
+            const result = checkWithValidator(
+              'id',
+              values[fieldName] ? values[fieldName].id : '',
+              { values, fieldName, schema },
+              ''
+            );
+            if (result) {
+              collector[fieldName] = result;
+            }
           }
         });
       return collector;

--- a/packages/validation/src/types.ts
+++ b/packages/validation/src/types.ts
@@ -1,6 +1,7 @@
 export type Condition = Value | RichCondition;
 
 export interface ExtSchemaContext extends SchemaContext {
+  computedFieldName?: string;
   comparableField?: string;
   comparableValue?: Value;
   isString?: boolean;

--- a/packages/validation/src/validators.ts
+++ b/packages/validation/src/validators.ts
@@ -14,7 +14,8 @@ export const supportedValidators = {
   email: { createMsg: () => `Invalid email address` },
   alphaNumeric: { createMsg: () => `Only alphanumeric characters` },
   phoneNumber: { createMsg: () => `Invalid phone number, must be 10 digits` },
-  equals: { createMsg: ({ comparableValue }: ExtSchemaContext) => `Should match '${comparableValue}'` }
+  equals: { createMsg: ({ comparableValue }: ExtSchemaContext) => `Should match '${comparableValue}'` },
+  id: { createMsg: ({ computedFieldName }: ExtSchemaContext) => `${computedFieldName} must be selected` }
 };
 
 let messages: any = {};
@@ -63,6 +64,14 @@ const phoneNumber = (value: string, msg?: string) => (context: SchemaContext): s
 const equals = (value: Value, msg?: string) => (context: SchemaContext, comparableValue: Value): string | undefined =>
   value !== comparableValue ? msg || pickMsg('equals', { ...context, comparableValue }) : undefined;
 
+// Id validation
+const id = (value: Value, msg?: string) => (context: SchemaContext): string | undefined => {
+  const computedFieldName = context.schema[context.fieldName].type
+    ? context.schema[context.fieldName].type.name
+    : context.fieldName;
+  return !value || isNaN(Number(value)) ? msg || pickMsg('id', { ...context, computedFieldName }) : undefined;
+};
+
 /* HELPERS */
 
 // Provides a message
@@ -79,5 +88,6 @@ export default {
   email,
   alphaNumeric,
   phoneNumber,
-  equals
+  equals,
+  id
 };


### PR DESCRIPTION
Add domain schema id validation. When we use validation for form we must check id for related domain-schema. So I added check id for related domain-schema instead of recursion look up all nested fields. This validation will be triggered if domain-schema relation established with property - optional.